### PR TITLE
Fix endpoint @redis-clear-cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix endpoint @redis-clear-cache
+  [masipcat]
 
 
 2.1.0 (2018-11-20)

--- a/guillotina_rediscache/api.py
+++ b/guillotina_rediscache/api.py
@@ -26,10 +26,8 @@ async def stats(context, request):
 async def clear(context, request):
     memory_cache = cache.get_memory_cache()
     memory_cache.clear()
-    pool = await cache.get_redis_pool()
-    conn = await pool.acquire()
-    await conn.flushall()
-    pool.release(conn)
+    redis = aioredis.Redis(await cache.get_redis_pool())
+    await redis.flushall()
     return {
         'success': True
     }


### PR DESCRIPTION
This endpoint was crashing because `conn` doesn't have `flushall()`